### PR TITLE
Avoid ArgumentNullException under WinRT

### DIFF
--- a/src/Ninject/Selection/Selector.cs
+++ b/src/Ninject/Selection/Selector.cs
@@ -108,7 +108,7 @@ namespace Ninject.Selection
             properties.AddRange(
                 type.GetRuntimeProperties().FilterPublic(Settings.InjectNonPublic)
                     .Select(p => p.GetPropertyFromDeclaredType(p))
-                    .Where(p => this.InjectionHeuristics.Any(h => h.ShouldInject(p))));
+                    .Where(p => this.InjectionHeuristics.Any(h => p != null && h.ShouldInject(p))));
 #endif
 #if !SILVERLIGHT 
             if (this.Settings.InjectParentPrivateProperties)


### PR DESCRIPTION
The WinRT implementation of GetPropertyFromDeclaredType() will return
null is no suitable property is found, or the property is static, if
unchecked this causes an unhandled ArgumentNullException in
ShouldInject(). This is particularly the event if binding a singleton type
with a static Instance property.
